### PR TITLE
Add another display helper

### DIFF
--- a/Core/LWEUniversalAppHelpers.h
+++ b/Core/LWEUniversalAppHelpers.h
@@ -86,7 +86,10 @@ typedef enum
 //! Determines if the device is an 4" retina display or not. Works with pre 3.2 iOS versions as well
 +(BOOL)isFourInchRetinaDisplay;
 
-/** Used by client code when running with a non 4" screen that wants to adjust layout optimized for 4" */
+/**
+ * Used by client code when running with a non 4" screen that wants to adjust layout optimized for 4"
+ * NOTE: Currently this method returns incorrect results when run in the resizable iPhone simulator.
+ */
 + (CGFloat)screenHeightDifferenceFrom4InchDisplay;
 
 /** Used by client code when running with a non 4" screen that wants to adjust layout optimized for 4" */

--- a/Core/LWEUniversalAppHelpers.m
+++ b/Core/LWEUniversalAppHelpers.m
@@ -74,10 +74,7 @@ static const CGFloat FourInchDisplayHeight = 568.0;
 
 + (CGFloat)screenHeight_
 {
-  // Currently [UIScreen mainScreen].bounds.size.height is incorrect in the resizable iPhone simulator; if
-  // this gets straightened out then we can go back to that.
-  //return [UIScreen mainScreen].bounds.size.height;
-  return [UIApplication sharedApplication].keyWindow.bounds.size.height;
+  return [UIScreen mainScreen].bounds.size.height;
 }
 
 + (BOOL)isTouchIDAvailable


### PR DESCRIPTION
This PR adds a method to return the standard 4" display height of 568.0 for client code that needs it, plus fixes a bug with an earlier workaround for large screen sizes.
