### PR TITLE
Remove dependency on MT main repo xcode proj PCH file includes in LWE file

### DIFF
--- a/Keychain/MTKeychainWrapper.m
+++ b/Keychain/MTKeychainWrapper.m
@@ -20,7 +20,6 @@
 
 #import "MTKeychainWrapper.h"
 #import "LWEDebug.h"
-#import "Constants.h"
 
 static NSString * const LWEKeychainDictionaryKey = @"LWEKeychainDictionaryKey";
 
@@ -101,7 +100,10 @@ static NSString * const LWEKeychainDictionaryKey = @"LWEKeychainDictionaryKey";
   }
 
   OSStatus status = SecItemDelete((__bridge CFDictionaryRef)keychainQuery);
-  MT_ASSERT(status == noErr || status == errSecItemNotFound, @"Problem deleting keychain items: %d", (int)status);
+  if (status != noErr && status != errSecItemNotFound)
+  {
+    NSLog(@"Problem deleting keychain items: %d", (int)status);
+  }
 }
 
 #pragma mark - Privates


### PR DESCRIPTION
Longer term we will most likely bring all the LWE code we need into the main repo, at which point it will be fine to have a dependency like that, so we could go back to using MT_ASSERT and #import whatever file that macro lives in at that point (hopefully not Constants.h).
