### PR TITLE
PFM-924: Remove comments from function

### DIFF
--- a/Core/LWEFile.m
+++ b/Core/LWEFile.m
@@ -316,20 +316,6 @@
 + (NSInteger) getTotalDiskSpaceInBytes
 {
   NSInteger totalSpace = 0;
-//  NSError *error = nil;
-//  NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-//  NSDictionary *dictionary = [[NSFileManager defaultManager] attributesOfFileSystemForPath:[paths lastObject] error: &error];
-//  LWE_LOG(@"Last object was: %@",[paths lastObject]);
-//  if (dictionary)
-//  {
-//    NSNumber *fileSystemSizeInBytes = [dictionary objectForKey:NSFileSystemSize];
-//    totalSpace = [fileSystemSizeInBytes intValue];
-//    LWE_LOG(@"File system size: %d",[fileSystemSizeInBytes intValue])
-//  }
-//  else
-//  {
-//    LWE_LOG(@"Error Obtaining File System Info: Domain = %@, Code = %@", [error domain], [error code]);
-//  }
   // TODO: this code doesn't work on iPod Touch and maybe other devices.  So I'm assuming it's all good for now
   totalSpace = 100000000;
   return totalSpace;


### PR DESCRIPTION
Besides this function is not doing anything, it is possible that the commented reference of the `NSFileSystemSize` key is being taken into account as a required reason API. 
See https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278397

Related ticket: https://moneytree-app.atlassian.net/browse/PFM-924